### PR TITLE
Use Flask's preferred JSON module.

### DIFF
--- a/flaskext/testing.py
+++ b/flaskext/testing.py
@@ -13,9 +13,13 @@ from __future__ import absolute_import
 import StringIO
 import unittest
 import twill
-import simplejson
 
 from werkzeug import cached_property
+
+# Use Flask's preferred JSON module so that our runtime behavior matches.
+from flask import json_available
+if json_available:
+    from flask import json
 
 try:
     # we'll use signals for template-related tests if
@@ -37,7 +41,9 @@ class JsonResponseMixin(object):
     """
     @cached_property
     def json(self):
-        return simplejson.loads(self.data)
+        if not json_available:
+            raise NotImplementedError
+        return json.loads(self.data)
 
 
 def _make_test_response(response_class):

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
     install_requires=[
         'Flask',
         'twill',
-        'simplejson',
     ],
     tests_require=[
         'nose',


### PR DESCRIPTION
This ensures that our runtime behavior matches Flask's.  It also lets
us remove our dependency on simplejson, which isn't needed when
running a sufficiently-new version of Python.
