### PR TITLE
Append parent dir to sys.path for autodoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,8 @@ import sys, os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.append(os.path.abspath('_themes'))
 
 # -- General configuration -----------------------------------------------------


### PR DESCRIPTION
This was previously failing with:

index.rst:158: WARNING: autodoc can't import/find class
'flaskext.testing.TestCase', it reported error: "No module named 
flaskext.testing", please check your spelling and sys.path

Now the rendered docs include the API docs.
