### PR TITLE
LiveServerTestCase usingo tornado (issue: #33)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ tests_require = [
 ]
 
 install_requires = [
-    'Flask'
+    'Flask',
+    'tornado'
 ]
 
 if sys.version_info < (2, 6):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ tests_require = [
 
 install_requires = [
     'Flask',
-    'tornado'
+    'tornado==3.2'
 ]
 
 if sys.version_info < (2, 6):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,14 +105,14 @@ class TestLiveServer(LiveServerTestCase):
             app.config['LIVESERVER_PORT'] = 8943
             return app
 
-        def test_server_process_is_spawned(self):
-            process = self._process
+        def test_server_thread_is_spawned(self):
+            thread = self._thread
 
             # Check the process is spawned
-            self.assertNotEqual(process, None)
+            self.assertNotEqual(thread, None)
 
             # Check the process is alive
-            self.assertTrue(process.is_alive())
+            self.assertTrue(thread.is_alive())
 
         def test_server_listening(self):
             response = urllib2.urlopen(self.get_server_url())


### PR DESCRIPTION
- use tornado and spawn the server process in a thread instead of a process
- rename _pre_setup & _post_teardown to have a _live suffix so that
  derived test classes can choose to extend both LiveServerTestCase & TestCase

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jarus/flask-testing/35)
<!-- Reviewable:end -->
