### PR TITLE
Enabled the use of unittest2 when available

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -12,7 +12,10 @@ from __future__ import absolute_import, with_statement
 
 import gc
 import time
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import multiprocessing
 
 from werkzeug import cached_property


### PR DESCRIPTION
Hello again,

This is a very tiny pull request to favor unittest2 when available for Python 2.6 users.  This relates to issue https://github.com/jarus/flask-testing/issues/31

Cheers
Fotis
