### PR TITLE
Ensure _post_teardown doesn't fail if _pre_setup fails

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -83,6 +83,7 @@ class TestCase(unittest.TestCase):
         means you don't have to call super.setUp
         in subclasses.
         """
+        self.app = self._ctx = self.client = self.templates = None
         try:
             self._pre_setup()
             super(TestCase, self).__call__(result)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,13 +2,14 @@ import unittest
 
 from flask_testing import is_twill_available
 
-from .test_utils import TestSetup, TestClientUtils, TestLiveServer
+from .test_utils import TestSetup, TestSetupFailure, TestClientUtils, TestLiveServer
 from .test_twill import TestTwill, TestTwillDeprecated
 
 
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestSetup))
+    suite.addTest(unittest.makeSuite(TestSetupFailure))
     suite.addTest(unittest.makeSuite(TestClientUtils))
     suite.addTest(unittest.makeSuite(TestLiveServer))
     if is_twill_available:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,16 @@ class TestSetup(TestCase):
         self.assertTrue(self._ctx is not None)
 
 
+class TestSetupFailure(TestCase):
+
+    def _pre_setup(self):
+        pass
+
+    def test_setup_failure(self):
+        '''Should not fail in _post_teardown if _pre_setup fails'''
+        assert True
+
+
 class TestClientUtils(TestCase):
 
     def create_app(self):


### PR DESCRIPTION
This pull-request ensure the _post_teardown method doesn't fails if _pre_setup fails.
This way the _post_teardown method is always fully executed and _pre_setup errors are not hidden anymore to the user.
