### PR TITLE
Improve error message generated by assertRedirects

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -204,7 +204,9 @@ class TestCase(unittest.TestCase):
         :param response: Flask response
         :param location: relative URL (i.e. without **http://localhost**)
         """
-        self.assertTrue(response.status_code in (301, 302))
+        self.assertTrue(
+            response.status_code in (301, 302),
+            "%s not found in (301, 302)" % response.status_code)
         self.assertEqual(response.location, "http://localhost" + location)
 
     assert_redirects = assertRedirects

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,6 +51,13 @@ class TestClientUtils(TestCase):
         response = self.client.get("/redirect/")
         self.assertRedirects(response, "/")
 
+    def test_redirects_error_message(self):
+        response = self.client.get("/")
+        self.assertRaisesRegexp(
+            AssertionError,
+            "200 not found in \(301, 302\)",
+            lambda: self.assertRedirects(response, "/"))
+
     def test_assert_template_used(self):
         try:
             self.client.get("/template/")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,10 +53,12 @@ class TestClientUtils(TestCase):
 
     def test_redirects_error_message(self):
         response = self.client.get("/")
-        with self.assertRaises(AssertionError) as cm:
+        try:
             self.assertRedirects(response, "/")
-        exception = cm.exception
-        self.assertEqual(str(exception), "200 not found in (301, 302)")
+        except AssertionError as exc:
+            self.assertTrue(str(exc).endswith("200 not found in (301, 302)"))
+        else:
+            assert False, "AssertionError is not raised"
 
     def test_assert_template_used(self):
         try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,7 +56,7 @@ class TestClientUtils(TestCase):
         with self.assertRaises(AssertionError) as cm:
             self.assertRedirects(response, "/")
         exception = cm.exception
-        self.assertEqual(exception.message, "False is not True : 200 not found in (301, 302)")
+        self.assertEqual(str(exception), "200 not found in (301, 302)")
 
     def test_assert_template_used(self):
         try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,10 +53,10 @@ class TestClientUtils(TestCase):
 
     def test_redirects_error_message(self):
         response = self.client.get("/")
-        self.assertRaisesRegexp(
-            AssertionError,
-            "200 not found in \(301, 302\)",
-            lambda: self.assertRedirects(response, "/"))
+        with self.assertRaises(AssertionError) as cm:
+            self.assertRedirects(response, "/")
+        exception = cm.exception
+        self.assertEqual(exception.message, "False is not True : 200 not found in (301, 302)")
 
     def test_assert_template_used(self):
         try:


### PR DESCRIPTION
At the moment exception thrown by assertRedirects is somewhat obscure: 

"AssertionError: False is not true". 

It would be nicer to have actual status code in the message. This change addresses it. Now it is like:

"AssertionError: 200 not found in (301, 302)" 
(In case of 200OK).