### PR TITLE
Fix wrong assumptions in assertRedirects

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -197,16 +197,17 @@ class TestCase(unittest.TestCase):
 
     assert_context = assertContext
 
-    def assertRedirects(self, response, location):
+    def assertRedirects(self, response, location=None):
         """
         Checks if response is an HTTP redirect to the
-        given location.
+        given location (if any).
 
         :param response: Flask response
-        :param location: relative URL (i.e. without **http://localhost**)
+        :param location: complete URL or ``None`` to skip location check
         """
         self.assertTrue(response.status_code in (301, 302))
-        self.assertEqual(response.location, "http://localhost" + location)
+        if location is not None:
+            self.assertEqual(response.location, location)
 
     assert_redirects = assertRedirects
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,7 +59,7 @@ class TestClientUtils(TestCase):
 
     def test_assert_redirects(self):
         response = self.client.get("/redirect/")
-        self.assertRedirects(response, "/")
+        self.assertRedirects(response, "http://localhost/")
 
     def test_assert_template_used(self):
         try:


### PR DESCRIPTION
Fixes #52 

* Make the location check optional
* Don't make any assumptions about the location URL