### PR TITLE
Use `urljoin()` in assertRedirects instead of string concatenation

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, with_statement
 
 import gc
 import time
+import urlparse
 try:
     import unittest2 as unittest
 except ImportError:

--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -12,7 +12,10 @@ from __future__ import absolute_import, with_statement
 
 import gc
 import time
-import urlparse
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 try:
     import unittest2 as unittest
 except ImportError:
@@ -212,7 +215,7 @@ class TestCase(unittest.TestCase):
         :param location: relative URL (i.e. without **http://localhost**)
         """
         self.assertTrue(response.status_code in (301, 302))
-        self.assertEqual(response.location, urlparse.urljoin('http://localhost', location))
+        self.assertEqual(response.location, urljoin('http://localhost', location))
 
     assert_redirects = assertRedirects
 

--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -211,7 +211,7 @@ class TestCase(unittest.TestCase):
         :param location: relative URL (i.e. without **http://localhost**)
         """
         self.assertTrue(response.status_code in (301, 302))
-        self.assertEqual(response.location, "http://localhost" + location)
+        self.assertEqual(response.location, urlparse.urljoin('http://localhost', location))
 
     assert_redirects = assertRedirects
 


### PR DESCRIPTION
String concatenation does not correctly detect redirects across domains. Using [`urlparse.urljoin()`](https://docs.python.org/2/library/urlparse.html#urlparse.urljoin) accounts for the basic case already covered by simple concatenation, as well as redirects across domains.