### PR TITLE
Do not run tests twice when DEBUG is set to true (related: issue 33)

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -357,7 +357,7 @@ class LiveServerTestCase(unittest.TestCase):
         self._process = None
         self.port = self.app.config.get('LIVESERVER_PORT', 5000)
 
-        worker = lambda app, port: app.run(port=port)
+        worker = lambda app, port: app.run(port=port, use_reloader=False)
 
         self._process = multiprocessing.Process(
             target=worker, args=(self.app, self.port)


### PR DESCRIPTION
Hey!

Apparently it is possible to simply disable reloader, so tests don't run twice when DEBUG is true. I think this makes issue 37 less severe.
