### PR TITLE
Give the live server a request context

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -345,10 +345,15 @@ class LiveServerTestCase(unittest.TestCase):
         # Get the app
         self.app = self.create_app()
 
+        # We need to create a context in order for extensions to catch up
+        self._ctx = self.app.test_request_context()
+        self._ctx.push()
+
         try:
             self._spawn_live_server()
             super(LiveServerTestCase, self).__call__(result)
         finally:
+            self._post_teardown()
             self._terminate_live_server()
 
     def get_server_url(self):
@@ -378,6 +383,11 @@ class LiveServerTestCase(unittest.TestCase):
                 timeout = 0
             except:
                 timeout -= 1
+
+    def _post_teardown(self):
+        if getattr(self, '_ctx', None) is not None:
+            self._ctx.pop()
+            del self._ctx
 
     def _terminate_live_server(self):
         if self._process:


### PR DESCRIPTION
This is essentially a convenience hack (which is very much in line with how the rest of flask-testing works) that creates a request context that we don't actually need. However, a request context in turn creates an app context which in turn makes our extensions work. As it is, the live server is essentially broken in all but the most trivial configurations.

It breaks flask-sqlalchemy as it is, due to: https://github.com/mitsuhiko/flask-sqlalchemy/blob/master/flask_sqlalchemy/__init__.py#L835

Tests work fine. I'm aware that we could do this with [app_context](http://flask.pocoo.org/docs/0.10/api/#flask.Flask.app_context) but frankly that would mean that users have to do more work on their side. The current method is costly but the cost pales compared to the rest of what a live testing server is used for anyway.

I'm confident this is a good change.
