### PR TITLE
Unquote response location in assertRedirect

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -22,6 +22,7 @@ except ImportError:
     from urllib.request import urlopen
 import multiprocessing
 
+from urllib import unquote
 from werkzeug import cached_property
 
 # Use Flask's preferred JSON module so that our runtime behavior matches.
@@ -215,7 +216,7 @@ class TestCase(unittest.TestCase):
         :param location: relative URL (i.e. without **http://localhost**)
         """
         self.assertTrue(response.status_code in (301, 302))
-        self.assertEqual(response.location, "http://localhost" + location)
+        self.assertEqual(unquote(response.location), "http://localhost" + location)
 
     assert_redirects = assertRedirects
 

--- a/tests/flask_app/__init__.py
+++ b/tests/flask_app/__init__.py
@@ -22,6 +22,10 @@ def create_app():
     def redirect_to_index():
         return redirect(url_for("index"))
 
+    @app.route("/redirect-next/")
+    def redirect_from_somewhere():
+        return redirect(url_for("index", next='/somewhere/'))
+
     @app.route("/ajax/")
     def ajax():
         return jsonify(name="test")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,6 +89,10 @@ class TestClientUtils(TestCase):
         response = self.client.get("/redirect/")
         self.assertRedirects(response, "/")
 
+    def test_assert_redirects_with_query(self):
+        response = self.client.get("/redirect-next/")
+        self.assertRedirects(response, "/?next=/somewhere/")
+
     def test_assert_template_used(self):
         try:
             self.client.get("/template/")


### PR DESCRIPTION
By default Flask url encodes query params which makes testing the location of a redirect slightly awkward.

eg. `self.assertRedirects(res, '/login?next=/somewhere/')` currently fails with 
`'http://localhost/?next=%2Fsomewhere%2F' != 'http://localhost/?next=/somewhere/'`

This fixes the problem by unquoting the response location before asserting equality.
