### PR TITLE
DEV: Make callable used to create a Process configurable.

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -336,6 +336,9 @@ class TestCase(unittest.TestCase):
 # Inspired by https://docs.djangoproject.com/en/dev/topics/testing/#django.test.LiveServerTestCase
 
 class LiveServerTestCase(unittest.TestCase):
+
+    process_factory = multiprocessing.Process
+
     def create_app(self):
         """
         Create your Flask app here, with any
@@ -375,7 +378,7 @@ class LiveServerTestCase(unittest.TestCase):
 
         worker = lambda app, port: app.run(port=port, use_reloader=False)
 
-        self._process = multiprocessing.Process(
+        self._process = self.process_factory(
             target=worker, args=(self.app, self.port)
         )
 


### PR DESCRIPTION
Allows users to specify an alternate callable to produce an object with
the same interface as a multiprocessing.Process.

Most notably, this is useful for spawning a server with a subclass of
multiprocessing.Process, such as the Gevent-aware Process subclass
implemented by [gipc](https://bitbucket.org/jgehrcke/gipc).