### PR TITLE
Build URL using the SERVER_NAME config in assertRedirects

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -223,8 +223,10 @@ class TestCase(unittest.TestCase):
         :param location: relative URL (i.e. without **http://localhost**)
         """
         server_name = self.app.config.get('SERVER_NAME') or 'localhost'
+        scheme = self.app.config.get('PREFERRED_URL_SCHEME') or 'http'
         self.assertTrue(response.status_code in (301, 302))
-        self.assertEqual(response.location, "http://" + server_name + location)
+        self.assertEqual(response.location,
+                         scheme + "://" + server_name + location)
 
     assert_redirects = assertRedirects
 

--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -222,8 +222,9 @@ class TestCase(unittest.TestCase):
         :param response: Flask response
         :param location: relative URL (i.e. without **http://localhost**)
         """
+        server_name = self.app.config.get('SERVER_NAME') or 'localhost'
         self.assertTrue(response.status_code in (301, 302))
-        self.assertEqual(response.location, "http://localhost" + location)
+        self.assertEqual(response.location, "http://" + server_name + location)
 
     assert_redirects = assertRedirects
 


### PR DESCRIPTION
Replace hard-coded "localhost" with SERVER_NAME config.

This allow to test applications using subdomain routes.