### PR TITLE
Optional message arguments for assertRedirects and assertContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.orig
 *~
 
+.eggs
 dist
+build
 docs/output
 docs/_build/

--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -222,7 +222,8 @@ class TestCase(unittest.TestCase):
         :param response: Flask response
         :param location: relative URL (i.e. without **http://localhost**)
         """
-        self.assertTrue(response.status_code in (301, 302))
+        failure_message = "HTTP Status 301 or 302 expected but got %d" % response.status_code
+        self.assertTrue(response.status_code in (301, 302), failure_message)
         self.assertEqual(response.location, "http://localhost" + location)
 
     assert_redirects = assertRedirects

--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -197,7 +197,7 @@ class TestCase(unittest.TestCase):
                 return context[name]
         raise ContextVariableDoesNotExist
 
-    def assertContext(self, name, value):
+    def assertContext(self, name, value, message=None):
         """
         Checks if given name exists in the template context
         and equals the given value.
@@ -208,13 +208,13 @@ class TestCase(unittest.TestCase):
         """
 
         try:
-            self.assertEqual(self.get_context_variable(name), value)
+            self.assertEqual(self.get_context_variable(name), value, message)
         except ContextVariableDoesNotExist:
-            self.fail("Context variable does not exist: %s" % name)
+            self.fail(message or "Context variable does not exist: %s" % name)
 
     assert_context = assertContext
 
-    def assertRedirects(self, response, location):
+    def assertRedirects(self, response, location, message=None):
         """
         Checks if response is an HTTP redirect to the
         given location.
@@ -222,9 +222,9 @@ class TestCase(unittest.TestCase):
         :param response: Flask response
         :param location: relative URL (i.e. without **http://localhost**)
         """
-        failure_message = "HTTP Status 301 or 302 expected but got %d" % response.status_code
-        self.assertTrue(response.status_code in (301, 302), failure_message)
-        self.assertEqual(response.location, "http://localhost" + location)
+        not_redirect = "HTTP Status 301 or 302 expected but got %d" % response.status_code
+        self.assertTrue(response.status_code in (301, 302), message or not_redirect)
+        self.assertEqual(response.location, "http://localhost" + location, message)
 
     assert_redirects = assertRedirects
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,6 +96,13 @@ class TestClientUtils(TestCase):
         except AssertionError as e:
             self.assertEqual(e.message, "HTTP Status 301 or 302 expected but got 200")
 
+    def test_assert_redirects_custom_message(self):
+        response = self.client.get("/")
+        try:
+            self.assertRedirects(response, "/anything", "Custom message")
+        except AssertionError as e:
+            self.assertEqual(e.message, "Custom message")
+
     def test_assert_template_used(self):
         try:
             self.client.get("/template/")
@@ -127,6 +134,15 @@ class TestClientUtils(TestCase):
         except RuntimeError:
             pass
 
+    def test_assert_context_custom_message(self):
+        self.client.get("/template/")
+        try:
+            self.assert_context("name", "nothing", "Custom message")
+        except AssertionError as e:
+            self.assertEqual(e.message, "Custom message")
+        except RuntimeError:
+            pass
+
     def test_assert_bad_context(self):
         try:
             self.client.get("/template/")
@@ -134,6 +150,15 @@ class TestClientUtils(TestCase):
                               "name", "foo")
             self.assertRaises(AssertionError, self.assert_context,
                               "foo", "foo")
+        except RuntimeError:
+            pass
+
+    def test_assert_bad_context_custom_message(self):
+        self.client.get("/template/")
+        try:
+            self.assert_context("foo", "foo", "Custom message")
+        except AssertionError as e:
+            self.assertEqual(e.message, "Custom message")
         except RuntimeError:
             pass
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,16 +56,14 @@ class TestClientUtils(TestCase):
         try:
             self.assertStatus(self.client.get('/'), 404, expected_message)
         except AssertionError as e:
-            self.assertTrue(expected_message in e.args[0] or \
-                            expected_message in e.message)
+            self.assertTrue(expected_message in str(e))
 
     def test_default_status_failure_message(self):
         expected_message = 'HTTP Status 404 expected but got 200'
         try:
             self.assertStatus(self.client.get('/'), 404)
         except AssertionError as e:
-            self.assertTrue(expected_message in e.args[0] or \
-                            expected_message in e.message)
+            self.assertTrue(expected_message in str(e))
 
     def test_assert_200(self):
         self.assert200(self.client.get("/"))
@@ -94,14 +92,14 @@ class TestClientUtils(TestCase):
         try:
             self.assertRedirects(response, "/anything")
         except AssertionError as e:
-            self.assertEqual(e.message, "HTTP Status 301 or 302 expected but got 200")
+            self.assertTrue("HTTP Status 301 or 302 expected but got 200" in str(e))
 
     def test_assert_redirects_custom_message(self):
         response = self.client.get("/")
         try:
             self.assertRedirects(response, "/anything", "Custom message")
         except AssertionError as e:
-            self.assertEqual(e.message, "Custom message")
+            self.assertTrue("Custom message" in str(e))
 
     def test_assert_template_used(self):
         try:
@@ -139,7 +137,7 @@ class TestClientUtils(TestCase):
         try:
             self.assert_context("name", "nothing", "Custom message")
         except AssertionError as e:
-            self.assertEqual(e.message, "Custom message")
+            self.assertTrue("Custom message" in str(e))
         except RuntimeError:
             pass
 
@@ -158,7 +156,7 @@ class TestClientUtils(TestCase):
         try:
             self.assert_context("foo", "foo", "Custom message")
         except AssertionError as e:
-            self.assertEqual(e.message, "Custom message")
+            self.assertTrue("Custom message" in str(e))
         except RuntimeError:
             pass
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,6 +89,13 @@ class TestClientUtils(TestCase):
         response = self.client.get("/redirect/")
         self.assertRedirects(response, "/")
 
+    def test_assert_redirects_failure_message(self):
+        response = self.client.get("/")
+        try:
+            self.assertRedirects(response, "/anything")
+        except AssertionError as e:
+            self.assertEqual(e.message, "HTTP Status 301 or 302 expected but got 200")
+
     def test_assert_template_used(self):
         try:
             self.client.get("/template/")


### PR DESCRIPTION
This change adds optional message arguments for `assertRedirects` and `assertContext` to be consistent with the rest of the assertion methods in the library. Addresses #83 

There is also a change to add a better message for a non redirect within `assertRedirects`. Right before submitting this PR, I saw an open PR that includes a similar change. It looked like it had been sitting there for a while so I included the commit in this diff, but I'm happy to pull it out if needed.