### PR TITLE
Fix test runs for Python 3.4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.5"
   - "3.4"
   - "3.3"
   - "2.7"
@@ -13,6 +14,14 @@ matrix:
     - python: "3.3"
       env: FLASK=0.9
     - python: "3.3"
+      env: FLASK=0.8.1
+    - python: "3.4"
+      env: FLASK=0.9
+    - python: "3.4"
+      env: FLASK=0.8.1
+    - python: "3.5"
+      env: FLASK=0.9
+    - python: "3.5"
       env: FLASK=0.8.1
 install:
   - pip install flask==$FLASK coverage --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.4"
   - "3.3"
   - "2.7"
   - "2.6"
@@ -21,3 +22,4 @@ script:
 notifications:
   email:
     - christoph.heer@googlemail.com
+    - jonathan.como@gmail.com

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
 ]
 
 if sys.version_info[0] < 3:
-    tests_require.append('twill==0.9')
+    tests_require.append('twill==0.9.1')
 
 if sys.version_info < (2, 6):
     tests_require.append('simplejson')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,17 +2,22 @@ import unittest
 
 from flask_testing import is_twill_available
 
-from .test_utils import TestSetup, TestSetupFailure, TestClientUtils, TestLiveServer, TestTeardownGraceful
 from .test_twill import TestTwill, TestTwillDeprecated
+from .test_utils import TestSetup, TestSetupFailure, TestClientUtils, \
+        TestLiveServer, TestTeardownGraceful, TestRenderTemplates, \
+        TestNotRenderTemplates, TestRestoreTheRealRender
 
 
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestSetup))
     suite.addTest(unittest.makeSuite(TestSetupFailure))
-    suite.addTest(unittest.makeSuite(TestTeardownGraceful))
     suite.addTest(unittest.makeSuite(TestClientUtils))
     suite.addTest(unittest.makeSuite(TestLiveServer))
+    suite.addTest(unittest.makeSuite(TestTeardownGraceful))
+    suite.addTest(unittest.makeSuite(TestRenderTemplates))
+    suite.addTest(unittest.makeSuite(TestNotRenderTemplates))
+    suite.addTest(unittest.makeSuite(TestRestoreTheRealRender))
     if is_twill_available:
         suite.addTest(unittest.makeSuite(TestTwill))
         suite.addTest(unittest.makeSuite(TestTwillDeprecated))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -171,7 +171,7 @@ class TestNotRenderTemplates(TestCase):
     def test_assert_not_process_the_template(self):
         response = self.client.get("/template/")
 
-        assert "" == response.data
+        assert len(response.data) == 0
 
     def test_assert_template_rendered_signal_sent(self):
         self.client.get("/template/")
@@ -189,7 +189,7 @@ class TestRenderTemplates(TestCase):
     def test_assert_not_process_the_template(self):
         response = self.client.get("/template/")
 
-        assert "" != response.data
+        assert len(response.data) > 0
 
 
 class TestRestoreTheRealRender(TestCase):
@@ -206,4 +206,4 @@ class TestRestoreTheRealRender(TestCase):
 
         response = self.client.get("/template/")
 
-        assert "" != response.data
+        assert len(response.data) > 0


### PR DESCRIPTION
Uses data length comparison for some test assertions instead of using a string comparison, which doesn't work the same in python3 as python2. The tests are logically equivalent. Fixes #87 

Additionally updates the build matrix to be include newer python versions and avoid this in the future.

@dev-zero is this what you had in mind?