### PR TITLE
Fix assertMessageFlashed if no messages were flashed.

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -221,7 +221,7 @@ class TestCase(unittest.TestCase):
 
             used_templates.append(template)
 
-        raise AssertionError("template %s not used. Templates were used: %s" % (name, ' '.join(used_templates)))
+        raise AssertionError("Template %s not used. Templates were used: %s" % (name, ' '.join(repr(used_templates))))
 
     assert_template_used = assertTemplateUsed
 

--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -191,9 +191,9 @@ class TestCase(unittest.TestCase):
 
         for _message, _category in self.flashed_messages:
             if _message == message and _category == category:
-                    return True
+                return True
 
-            raise AssertionError("Message '%s' in category '%s' wasn't flashed" % (message, category))
+        raise AssertionError("Message '%s' in category '%s' wasn't flashed" % (message, category))
 
     assert_message_flashed = assertMessageFlashed
 

--- a/tests/flask_app/__init__.py
+++ b/tests/flask_app/__init__.py
@@ -28,6 +28,10 @@ def create_app():
         flash("Flashed message")
         return render_template("index.html")
 
+    @app.route("/no_flash/")
+    def index_without_flash():
+        return render_template("index.html")
+
     @app.route("/oops/")
     def bad_url():
         abort(404)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -182,10 +182,14 @@ class TestClientUtils(TestCase):
     def test_assert_flashed_messages_failed(self):
         try:
             self.client.get("/flash/")
-            self.assertMessageFlashed("Flask-testing has assertMessageFlashed now")
-            assert False
-        except AssertionError:
+            self.assertRaises(AssertionError, self.assertMessageFlashed, "Flask-testing has assertMessageFlashed now")
+        except RuntimeError:
             pass
+
+    def test_assert_no_flashed_messages_fail(self):
+        try:
+            self.client.get("/no_flash/")
+            self.assertRaises(AssertionError, self.assertMessageFlashed, "Flashed message")
         except RuntimeError:
             pass
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -113,9 +113,9 @@ class TestClientUtils(TestCase):
             pass
 
     def test_assert_template_not_used(self):
-        self.client.get("/")
+        self.client.get("/template/")
         try:
-            self.assertRaises(AssertionError, self.assert_template_used, "index.html")
+            self.assertRaises(AssertionError, self.assert_template_used, "invalid.html")
         except RuntimeError:
             pass
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,10 +115,7 @@ class TestClientUtils(TestCase):
     def test_assert_template_not_used(self):
         self.client.get("/")
         try:
-            self.assert_template_used("index.html")
-            assert False
-        except AssertionError:
-            pass
+            self.assertRaises(AssertionError, self.assert_template_used, "index.html")
         except RuntimeError:
             pass
 


### PR DESCRIPTION
Fixes broken test cases for assertMessageFlashed - now checks for exceptions using ``assertRaises`` instead of ``assert False``, which would always silently fail in the ``except`` block.

Handles case where no messages have been flashed yet by the time that ``assertMessageFlashed`` is called.

Fixes #95.