### PR TITLE
Add support for port 0 handling in LiveServerTestCase

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,6 +77,35 @@ PhantomJS you can use the LiveServerTestCase::
 The method ``get_server_url`` will return http://localhost:8943 in this case.
 
 
+Dynamic LiveServerTestCase port
+-------------------------------
+
+By default, ``LiveServerTestCase`` will use the pre-defined port for running the live server. If
+multiple tests need to run in parallel, the ``LIVESERVER_PORT`` can be set to ``0`` to have the
+underlying operating system pick an open port for the server. The full address of the running
+server can be accessed via the ``get_server_url`` call on the test case::
+
+
+    import urllib2
+    from flask import Flask
+    from flask_testing import LiveServerTestCase
+
+    class MyTest(LiveServerTestCase):
+
+        def create_app(self):
+            app = Flask(__name__)
+            app.config['TESTING'] = True
+
+            # Set to 0 to have the OS pick the port.
+            app.config['LIVESERVER_PORT'] = 0
+
+            return app
+
+        def test_server_is_up_and_running(self):
+            response = urllib2.urlopen(self.get_server_url())
+            self.assertEqual(response.code, 200)
+
+
 Testing JSON responses
 ----------------------
 
@@ -217,10 +246,10 @@ Running tests
 with unittest
 -------------
 
-I recommend you to put all your tests into one file so that you can use 
-the :func:`unittest.main` function. This function will discover all your test 
+I recommend you to put all your tests into one file so that you can use
+the :func:`unittest.main` function. This function will discover all your test
 methods in your :class:`TestCase` classes. Remember, the names of the test
-methods and classes must start with ``test`` (case-insensitive) so that 
+methods and classes must start with ``test`` (case-insensitive) so that
 they can be discovered.
 
 An example test file could look like this::

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,8 @@ from flask_testing import is_twill_available
 from .test_twill import TestTwill, TestTwillDeprecated
 from .test_utils import TestSetup, TestSetupFailure, TestClientUtils, \
         TestLiveServer, TestTeardownGraceful, TestRenderTemplates, \
-        TestNotRenderTemplates, TestRestoreTheRealRender
+        TestNotRenderTemplates, TestRestoreTheRealRender, \
+        TestLiveServerOSPicksPort
 
 
 def suite():
@@ -14,6 +15,7 @@ def suite():
     suite.addTest(unittest.makeSuite(TestSetupFailure))
     suite.addTest(unittest.makeSuite(TestClientUtils))
     suite.addTest(unittest.makeSuite(TestLiveServer))
+    suite.addTest(unittest.makeSuite(TestLiveServerOSPicksPort))
     suite.addTest(unittest.makeSuite(TestTeardownGraceful))
     suite.addTest(unittest.makeSuite(TestRenderTemplates))
     suite.addTest(unittest.makeSuite(TestNotRenderTemplates))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,7 +168,7 @@ class TestClientUtils(TestCase):
                               self.get_context_variable, "foo")
         except RuntimeError:
             pass
-        
+
     def test_assert_flashed_messages_succeed(self):
         try:
             self.client.get("/flash/")
@@ -191,12 +191,7 @@ class TestClientUtils(TestCase):
             pass
 
 
-class TestLiveServer(LiveServerTestCase):
-
-    def create_app(self):
-        app = create_app()
-        app.config['LIVESERVER_PORT'] = 8943
-        return app
+class BaseTestLiveServer(LiveServerTestCase):
 
     def test_server_process_is_spawned(self):
         process = self._process
@@ -211,6 +206,22 @@ class TestLiveServer(LiveServerTestCase):
         response = urlopen(self.get_server_url())
         self.assertTrue(b'OK' in response.read())
         self.assertEqual(response.code, 200)
+
+
+class TestLiveServer(BaseTestLiveServer):
+
+    def create_app(self):
+        app = create_app()
+        app.config['LIVESERVER_PORT'] = 8943
+        return app
+
+
+class TestLiveServerOSPicksPort(BaseTestLiveServer):
+
+    def create_app(self):
+        app = create_app()
+        app.config['LIVESERVER_PORT'] = 0
+        return app
 
 
 class TestNotRenderTemplates(TestCase):


### PR DESCRIPTION
Following this change, if the `LIVESERVER_PORT` is set to zero, then the port will be chosen by the operating system and the LiveServerTestCase will adapt accordingly. This requires a bit of a hack (unfortunately), but makes testing large amounts of concurrent LiveServerTestCases much safer.
