### PR TITLE
Changed assertRedirects accept all valid redirect status codes

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -296,7 +296,8 @@ class TestCase(unittest.TestCase):
             expected_location = urljoin("http://%s" % server_name, location)
 
         valid_status_codes = (301, 302, 303, 305, 307)
-        not_redirect = "HTTP Status 301, 302, 303, 305 or 307 expected but got %d" % response.status_code
+        valid_status_code_str = ', '.join(str(code) for code in valid_status_codes)
+        not_redirect = "HTTP Status %s expected but got %d" % (valid_status_code_str, response.status_code)
         self.assertTrue(response.status_code in valid_status_codes, message or not_redirect)
         self.assertEqual(response.location, expected_location, message)
 

--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -295,8 +295,9 @@ class TestCase(unittest.TestCase):
             server_name = self.app.config.get('SERVER_NAME') or 'localhost'
             expected_location = urljoin("http://%s" % server_name, location)
 
-        not_redirect = "HTTP Status 301 or 302 expected but got %d" % response.status_code
-        self.assertTrue(response.status_code in (301, 302), message or not_redirect)
+        valid_status_codes = (301, 302, 303, 305, 307)
+        not_redirect = "HTTP Status 301, 302, 303, 305 or 307 expected but got %d" % response.status_code
+        self.assertTrue(response.status_code in valid_status_codes, message or not_redirect)
         self.assertEqual(response.location, expected_location, message)
 
     assert_redirects = assertRedirects

--- a/tests/flask_app/__init__.py
+++ b/tests/flask_app/__init__.py
@@ -39,12 +39,8 @@ def create_app():
 
     @app.route("/redirect/")
     def redirect_to_index():
-        code = request.args.get('code')
-
-        if code:
-            return redirect(url_for("index"), code=code)
-        else:
-            return redirect(url_for("index"))
+        code = request.args.get('code') or 301
+        return redirect(url_for("index"), code=code)
 
     @app.route("/external_redirect/")
     def redirect_to_flask_docs():

--- a/tests/flask_app/__init__.py
+++ b/tests/flask_app/__init__.py
@@ -7,6 +7,7 @@ from flask import (
     render_template,
     url_for,
     flash,
+    request
 )
 
 
@@ -38,7 +39,12 @@ def create_app():
 
     @app.route("/redirect/")
     def redirect_to_index():
-        return redirect(url_for("index"))
+        code = request.args.get('code')
+
+        if code:
+            return redirect(url_for("index"), code=code)
+        else:
+            return redirect(url_for("index"))
 
     @app.route("/external_redirect/")
     def redirect_to_flask_docs():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,7 +96,7 @@ class TestClientUtils(TestCase):
         try:
             self.assertRedirects(response, "/anything")
         except AssertionError as e:
-            self.assertTrue("HTTP Status 301 or 302 expected but got 200" in str(e))
+            self.assertTrue("HTTP Status 301, 302, 303, 305 or 307 expected but got 200" in str(e))
 
     def test_assert_redirects_custom_message(self):
         response = self.client.get("/")
@@ -104,6 +104,15 @@ class TestClientUtils(TestCase):
             self.assertRedirects(response, "/anything", "Custom message")
         except AssertionError as e:
             self.assertTrue("Custom message" in str(e))
+
+    def test_assert_redirects_valid_status_codes(self):
+        valid_redirect_status_codes = (301, 302, 303, 305, 307)
+
+        for status_code in valid_redirect_status_codes:
+            response = self.client.get("/redirect/?code=" + str(status_code))
+            message = "assertRedirects fails for status code " + str(status_code)
+            self.assertRedirects(response, "/", message=message)
+            self.assertStatus(response, status_code)
 
     def test_assert_template_used(self):
         try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,7 +96,7 @@ class TestClientUtils(TestCase):
         try:
             self.assertRedirects(response, "/anything")
         except AssertionError as e:
-            self.assertTrue("HTTP Status 301, 302, 303, 305 or 307 expected but got 200" in str(e))
+            self.assertTrue("HTTP Status 301, 302, 303, 305, 307 expected but got 200" in str(e))
 
     def test_assert_redirects_custom_message(self):
         response = self.client.get("/")
@@ -110,9 +110,17 @@ class TestClientUtils(TestCase):
 
         for status_code in valid_redirect_status_codes:
             response = self.client.get("/redirect/?code=" + str(status_code))
-            message = "assertRedirects fails for status code " + str(status_code)
-            self.assertRedirects(response, "/", message=message)
+            self.assertRedirects(response, "/")
             self.assertStatus(response, status_code)
+
+    def test_assert_redirects_invalid_status_code(self):
+        status_code = 200
+        response = self.client.get("/redirect/?code=" + str(status_code))
+        self.assertStatus(response, status_code)
+        try:
+            self.assertRedirects(response, "/")
+        except AssertionError as e:
+            self.assertTrue("HTTP Status 301, 302, 303, 305, 307 expected but got 200" in str(e))
 
     def test_assert_template_used(self):
         try:


### PR DESCRIPTION
Changed assertRedirects to consider the status codes 301, 302, 303, 305 and 307 to be valid.

This PR fixes issue [101 - assertRedirect assumes that the status code is 301 or 302](https://github.com/jarus/flask-testing/issues/101#issuecomment-273681414)