### PR TITLE
Added more tests for assert_template_used failure modes

### DIFF
--- a/flask_testing/twill.py
+++ b/flask_testing/twill.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 import StringIO
 import twill
 
-from .utils import TestCase
+from flask_testing.utils import TestCase
 
 
 class Twill(object):

--- a/tests/flask_app/__init__.py
+++ b/tests/flask_app/__init__.py
@@ -7,7 +7,8 @@ from flask import (
     render_template,
     url_for,
     flash,
-    request
+    request,
+    Blueprint
 )
 
 
@@ -23,6 +24,13 @@ def create_app():
     @app.route("/template/")
     def index_with_template():
         return render_template("index.html", name="test")
+
+    bp = Blueprint("myblueprint", __name__)
+
+    @bp.route('/bppage/')
+    def bp_template():
+        return render_template('index.html', name='test')
+    app.register_blueprint(bp)
 
     @app.route("/flash/")
     def index_with_flash():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,7 @@ class TestSetupFailure(TestCase):
         '''Should not fail in _post_teardown if _pre_setup fails'''
         assert True
 
+
 class TestTeardownGraceful(TestCase):
 
     def create_app(self):
@@ -41,6 +42,7 @@ class TestTeardownGraceful(TestCase):
 
         del self.app
         del self._ctx
+
 
 class TestClientUtils(TestCase):
 
@@ -255,8 +257,51 @@ class TestNotRenderTemplates(TestCase):
 
     def test_assert_template_rendered_signal_sent(self):
         self.client.get("/template/")
-
         self.assert_template_used('index.html')
+
+    def test_template_types(self):
+        self.client.get("/template/")
+        name = 'index.html'
+        tmpl_name_attribute = 'name'
+
+        # code inside assert_template_used
+        used_templates = []
+        for template, context in self.templates:
+            if getattr(template, tmpl_name_attribute) == name:
+                pass
+
+            used_templates.append(template)
+        errmsg = "Template %s not used. Templates were used: %s" % (name, ' '.join(repr(used_templates)))
+
+        self.assertIsInstance(name, str)
+        self.assertIsInstance(' '.join(repr(used_templates)), str)
+        self.assertIsInstance(errmsg, str)
+
+    def _template_fail(self, badtemplate):
+        errmsg = 'Template {0} not used. Templates were used'.format(badtemplate)
+        with self.assertRaises(AssertionError) as cm:
+            self.assert_template_used(badtemplate)
+        self.assertIn(errmsg, str(cm.exception))
+
+    def test_assert_wrong_template(self):
+        # route name for index.html template
+        self.client.get("/template/")
+        self._template_fail('badtemplate.html')
+
+    def test_assert_template_no_name(self):
+        # route name for index.html template
+        self.client.get("/template/")
+        self._template_fail('')
+
+    def test_assert_template_misspelled(self):
+        # route name for index.html template
+        self.client.get("/template/")
+        self._template_fail('inde.html')
+
+    def test_assert_wrong_bp_template(self):
+        # route name for the blueprint template
+        self.client.get("/bppage/")
+        self._template_fail('badtemplate.html')
 
 
 class TestRenderTemplates(TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -273,9 +273,9 @@ class TestNotRenderTemplates(TestCase):
             used_templates.append(template)
         errmsg = "Template %s not used. Templates were used: %s" % (name, ' '.join(repr(used_templates)))
 
-        self.assertIsInstance(name, str)
-        self.assertIsInstance(' '.join(repr(used_templates)), str)
-        self.assertIsInstance(errmsg, str)
+        self.assertEqual(type(name), str)
+        self.assertEqual(type(' '.join(repr(used_templates))), str)
+        self.assertEqual(type(errmsg), str)
 
     def _template_fail(self, badtemplate):
         errmsg = 'Template {0} not used. Templates were used'.format(badtemplate)


### PR DESCRIPTION
This PR addresses #103 .  It merely adds a few additional tests to ensure the `assert_template_used` method fails properly.  The errors in #103 could not be recreated using the source code, due to a difference between the source code, and the pip-installed code.  

Source code 0.6.1: 
` raise AssertionError("Template %s not used. Templates were used: %s" % (name, ' '.join(repr(used_templates))))`

Pip-installed code 0.6.1:
`raise AssertionError("template %s not used. Templates were used: %s" % (name, ' '.join(used_templates)))`

The source code has the Template object wrapped in `repr` to format it into the string proper, whereas the pip-code does not.   I suggest a new pip release be made to reflect this and any other changes that have been made.   No fix was implemented but new tests were written nevertheless.  
