### PR TITLE
Let Flask manage its own request contexts

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -141,9 +141,6 @@ class TestCase(unittest.TestCase):
 
         self.client = self.app.test_client()
 
-        self._ctx = self.app.test_request_context()
-        self._ctx.push()
-
         if not self.render_templates:
             # Monkey patch the original template render with a empty render
             self._original_template_render = templating._render
@@ -167,10 +164,6 @@ class TestCase(unittest.TestCase):
         self.templates.append((template, context))
 
     def _post_teardown(self):
-        if getattr(self, '_ctx', None) is not None:
-            self._ctx.pop()
-            del self._ctx
-
         if getattr(self, 'app', None) is not None:
             if getattr(self, '_orig_response_class', None) is not None:
                 self.app.response_class = self._orig_response_class
@@ -431,15 +424,10 @@ class LiveServerTestCase(unittest.TestCase):
         self._configured_port = self.app.config.get('LIVESERVER_PORT', 5000)
         self._port_value = multiprocessing.Value('i', self._configured_port)
 
-        # We need to create a context in order for extensions to catch up
-        self._ctx = self.app.test_request_context()
-        self._ctx.push()
-
         try:
             self._spawn_live_server()
             super(LiveServerTestCase, self).__call__(result)
         finally:
-            self._post_teardown()
             self._terminate_live_server()
 
     def get_server_url(self):
@@ -534,11 +522,6 @@ class LiveServerTestCase(unittest.TestCase):
                 )
 
         return host, port
-
-    def _post_teardown(self):
-        if getattr(self, '_ctx', None) is not None:
-            self._ctx.pop()
-            del self._ctx
 
     def _terminate_live_server(self):
         if self._process:

--- a/tests/flask_app/__init__.py
+++ b/tests/flask_app/__init__.py
@@ -7,7 +7,8 @@ from flask import (
     render_template,
     url_for,
     flash,
-    request
+    request,
+    g
 )
 
 
@@ -19,6 +20,14 @@ def create_app():
     @app.route("/")
     def index():
         return Response("OK")
+
+    @app.route("/context")
+    def context():
+        if hasattr(g, "thing"):
+            return "ALREADY SET"
+
+        g.thing = True
+        return "SET"
 
     @app.route("/template/")
     def index_with_template():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -83,9 +83,9 @@ class TestClientUtils(TestCase):
 
     def test_new_context_used_per_request(self):
         response = self.client.get("/context")
-        self.assertEqual(response.data, "SET")
+        self.assertEqual(response.data, b"SET")
         response = self.client.get("/context")
-        self.assertEqual(response.data, "SET")
+        self.assertEqual(response.data, b"SET")
 
     def test_assert_redirects(self):
         response = self.client.get("/redirect/")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,6 @@ class TestSetup(TestCase):
     def test_setup(self):
         self.assertTrue(self.app is not None)
         self.assertTrue(self.client is not None)
-        self.assertTrue(self._ctx is not None)
 
 
 class TestSetupFailure(TestCase):
@@ -40,7 +39,6 @@ class TestTeardownGraceful(TestCase):
         """
 
         del self.app
-        del self._ctx
 
 class TestClientUtils(TestCase):
 
@@ -82,6 +80,12 @@ class TestClientUtils(TestCase):
 
     def test_assert_500(self):
         self.assert500(self.client.get("/internal_server_error/"))
+
+    def test_new_context_used_per_request(self):
+        response = self.client.get("/context")
+        self.assertEqual(response.data, "SET")
+        response = self.client.get("/context")
+        self.assertEqual(response.data, "SET")
 
     def test_assert_redirects(self):
         response = self.client.get("/redirect/")


### PR DESCRIPTION
Don't manage the context stack in the test setup / teardown. Instead, let Flask handle it. This fixes the issue where global and request context was being reused on subsequent test client requests within the same test case.

I'm a bit concerned that there are some people relying on the fact that the context exists in the setup method for things like attaching global context. While its not a good practice, I wouldn't want to break others test suites with this change.

Fixes #105 