### PR TITLE
switch to using a thread for the live server

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -210,14 +210,14 @@ class TestClientUtils(TestCase):
 
 class BaseTestLiveServer(LiveServerTestCase):
 
-    def test_server_process_is_spawned(self):
-        process = self._process
+    def test_server_thread_is_spawned(self):
+        thread = self._thread
 
-        # Check the process is spawned
-        self.assertNotEqual(process, None)
+        # Check the thread is spawned
+        self.assertNotEqual(thread, None)
 
-        # Check the process is alive
-        self.assertTrue(process.is_alive())
+        # Check the thread is alive
+        self.assertTrue(thread.is_alive())
 
     def test_server_listening(self):
         response = urlopen(self.get_server_url())


### PR DESCRIPTION
Running the server in a thread works quite well, and prevents any
issues with communication between processes. Furthermore, it fixes
stdio capturing to work as expected.

Tested by using something similar in my own test suite on Python 3.6, and by running `Flask-Testing`'s own suite on Python 2.6, 2.7 and 3.6.