### PR TITLE
Optionally create a single app instance per test case class

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,6 +121,23 @@ a special ``json`` attribute appended to the ``Response`` object::
             response = self.client.get("/ajax/")
             self.assertEquals(response.json, dict(success=True))
 
+
+Single app instance
+-------------------
+
+In some cases, creating the app instance can be expensive. If you want to create one
+app instance per TestCase class, you can use the ``create_app_once`` flag. This works
+on both TestCase and LiveServerTestCase and is not enabled by default::
+
+    from flask_testing import TestCase
+
+    class MyTest(TestCase):
+        create_app_once = True
+
+        def test_something(self):
+            pass
+
+
 Opt to not render the templates
 -------------------------------
 

--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -57,7 +57,7 @@ try:
 except ImportError:  # pragma: no cover
     _is_signals = False
 
-__all__ = ["TestCase"]
+__all__ = ('TestCase', 'LiveServerTestCase')
 
 
 class ContextVariableDoesNotExist(Exception):
@@ -412,6 +412,9 @@ class TestCase(unittest.TestCase):
 # Inspired by https://docs.djangoproject.com/en/dev/topics/testing/#django.test.LiveServerTestCase
 
 class LiveServerTestCase(unittest.TestCase):
+    create_app_once = False
+    _app_instance = None
+
     def create_app(self):
         """
         Create your Flask app here, with any
@@ -426,7 +429,7 @@ class LiveServerTestCase(unittest.TestCase):
         """
 
         # Get the app
-        self.app = self.create_app()
+        self.app = self._get_or_create_app()
 
         self._configured_port = self.app.config.get('LIVESERVER_PORT', 5000)
         self._port_value = multiprocessing.Value('i', self._configured_port)
@@ -442,6 +445,23 @@ class LiveServerTestCase(unittest.TestCase):
         Return the url of the test server
         """
         return 'http://localhost:%s' % self._port_value.value
+
+    def _get_or_create_app(self):
+        """
+        This is a lazy way of doing class setup since we want to be consistent
+        and not have users call super in setUpClass if they do not call it in
+        setUp. Returns the singleton app if the test case has specified using
+        a single app (also could not do this in a class method since create_app
+        is not a classmethod).
+        """
+        cls = self.__class__
+        if not cls.create_app_once:
+            return self.create_app()
+
+        if not cls._app_instance:
+            cls._app_instance = self.create_app()
+
+        return cls._app_instance
 
     def _spawn_live_server(self):
         self._process = None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,19 +4,20 @@ from flask_testing import is_twill_available
 
 from .test_twill import TestTwill, TestTwillDeprecated
 from .test_utils import TestSetup, TestSetupFailure, TestClientUtils, \
-        TestLiveServer, TestTeardownGraceful, TestRenderTemplates, \
-        TestNotRenderTemplates, TestRestoreTheRealRender, \
-        TestLiveServerOSPicksPort, TestLiveServerReuseApp
+     TestLiveServer, TestTeardownGraceful, TestRenderTemplates, \
+     TestNotRenderTemplates, TestRestoreTheRealRender, TestSingletonApp, \
+     TestLiveServerOSPicksPort, TestLiveServerSingletonApp
 
 
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestSetup))
     suite.addTest(unittest.makeSuite(TestSetupFailure))
+    suite.addTest(unittest.makeSuite(TestSingletonApp))
     suite.addTest(unittest.makeSuite(TestClientUtils))
     suite.addTest(unittest.makeSuite(TestLiveServer))
     suite.addTest(unittest.makeSuite(TestLiveServerOSPicksPort))
-    suite.addTest(unittest.makeSuite(TestLiveServerReuseApp))
+    suite.addTest(unittest.makeSuite(TestLiveServerSingletonApp))
     suite.addTest(unittest.makeSuite(TestTeardownGraceful))
     suite.addTest(unittest.makeSuite(TestRenderTemplates))
     suite.addTest(unittest.makeSuite(TestNotRenderTemplates))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,7 @@ from .test_twill import TestTwill, TestTwillDeprecated
 from .test_utils import TestSetup, TestSetupFailure, TestClientUtils, \
         TestLiveServer, TestTeardownGraceful, TestRenderTemplates, \
         TestNotRenderTemplates, TestRestoreTheRealRender, \
-        TestLiveServerOSPicksPort
+        TestLiveServerOSPicksPort, TestLiveServerReuseApp
 
 
 def suite():
@@ -16,6 +16,7 @@ def suite():
     suite.addTest(unittest.makeSuite(TestClientUtils))
     suite.addTest(unittest.makeSuite(TestLiveServer))
     suite.addTest(unittest.makeSuite(TestLiveServerOSPicksPort))
+    suite.addTest(unittest.makeSuite(TestLiveServerReuseApp))
     suite.addTest(unittest.makeSuite(TestTeardownGraceful))
     suite.addTest(unittest.makeSuite(TestRenderTemplates))
     suite.addTest(unittest.makeSuite(TestNotRenderTemplates))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -245,6 +245,23 @@ class TestLiveServerOSPicksPort(BaseTestLiveServer):
         return app
 
 
+class TestLiveServerReuseApp(BaseTestLiveServer):
+    create_app_once = True
+    apps_created = 0
+
+    def create_app(self):
+        self.__class__.apps_created += 1
+        app = create_app()
+        return app
+
+    def test_created_single_app(self):
+        self.assertEqual(1, self.apps_created)
+
+    def test_created_single_app_sanity(self):
+        # In case they run out of order
+        self.assertEqual(1, self.apps_created)
+
+
 class TestNotRenderTemplates(TestCase):
 
     render_templates = False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,6 +40,22 @@ class TestTeardownGraceful(TestCase):
 
         del self.app
 
+
+class TestSingletonApp(TestCase):
+    create_app_once = True
+    apps_created = 0
+
+    def create_app(self):
+        self.__class__.apps_created += 1
+        return create_app()
+
+    def test_create_app_once(self):
+        self.assertEqual(self.apps_created, 1)
+
+    def test_create_app_once_sanity(self):
+        # In case sorting method changes
+        self.assertEqual(self.apps_created, 1)
+
 class TestClientUtils(TestCase):
 
     def create_app(self):
@@ -245,14 +261,13 @@ class TestLiveServerOSPicksPort(BaseTestLiveServer):
         return app
 
 
-class TestLiveServerReuseApp(BaseTestLiveServer):
+class TestLiveServerSingletonApp(BaseTestLiveServer):
     create_app_once = True
     apps_created = 0
 
     def create_app(self):
         self.__class__.apps_created += 1
-        app = create_app()
-        return app
+        return create_app()
 
     def test_created_single_app(self):
         self.assertEqual(1, self.apps_created)


### PR DESCRIPTION
Addresses #115 

@acidjunk what do you think about this implementation? This flag can be set per TestCase class and otherwise changes nothing (same process for CI without having to run external servers).