### PR TITLE
 Make _add_template add to list, not overwrite it.

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -169,9 +169,7 @@ class TestCase(unittest.TestCase):
         self.flashed_messages.append((message, category))
 
     def _add_template(self, app, template, context):
-        if len(self.templates) > 0:
-            self.templates = []
-        self.templates.append((template, context))
+        self.templates.insert(0, (template, context))
 
     def _post_teardown(self):
         if getattr(self, '_ctx', None) is not None:


### PR DESCRIPTION
Fix #38 get_context_variable and other functions support looping through a list of templates. Unfortunately this list currently always has at most 1 element which looks like a bug. This change allows testing requests that use multiple render_template calls as long as the parameter name is different. It should not have any other problems.
