### PR TITLE
adding the ability to set the host on the flask app for using a remot…

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -435,6 +435,7 @@ class LiveServerTestCase(unittest.TestCase):
         # Get the app
         self.app = self.create_app()
 
+        self._configured_host = self.app.config.get('LIVESERVER_HOST', 'localhost')
         self._configured_port = self.app.config.get('LIVESERVER_PORT', 5000)
         self._port_value = multiprocessing.Value('i', self._configured_port)
 
@@ -453,7 +454,7 @@ class LiveServerTestCase(unittest.TestCase):
         """
         Return the url of the test server
         """
-        return 'http://localhost:%s' % self._port_value.value
+        return 'http://{}:{}'.format(self._configured_host, self._port_value.value)
 
     def _spawn_live_server(self):
         self._process = None
@@ -477,7 +478,7 @@ class LiveServerTestCase(unittest.TestCase):
                 return ret
 
             socketserver.TCPServer.server_bind = socket_bind_wrapper
-            app.run(port=port, use_reloader=False)
+            app.run(port=port, use_reloader=False, host=self._configured_host)
 
         self._process = multiprocessing.Process(
             target=worker, args=(self.app, self._configured_port)


### PR DESCRIPTION
…e selenium server

My usecase was that I wanted to have testing done using docker compose and selenium/standalone-chrome.  Since they run in different containers you need to bind the host to 0.0.0.0 or the selenium container cannot access the LiveServer. 

These changes allow you to configure your app to change the host that the LiveServer starts on like this: 

`    def create_app(self):
        app.config.update(
            LIVESERVER_PORT=8943,
            LIVESERVER_HOST='0.0.0.0'
        )
`
