### PR TITLE
Fix import json_available error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,24 @@ python:
   - "2.7"
   - "2.6"
 env:
+  - FLASK=1.1.0
+  - FLASK=1.0.2
   - FLASK=0.11.1
   - FLASK=0.10.1
   - FLASK=0.9
   - FLASK=0.8.1
 matrix:
   exclude:
+    - python: "2.6"
+      env: FLASK=1.1.0
+    - python: "3.3"
+      env: FLASK=1.1.0
     - python: "3.3"
       env: FLASK=0.9
     - python: "3.3"
       env: FLASK=0.8.1
+    - python: "3.4"
+      env: FLASK=1.1.0
     - python: "3.4"
       env: FLASK=0.9
     - python: "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.6"
   - "3.5"
   - "3.4"
   - "3.3"
@@ -31,6 +32,10 @@ matrix:
     - python: "3.5"
       env: FLASK=0.9
     - python: "3.5"
+      env: FLASK=0.8.1
+    - python: "3.6"
+      env: FLASK=0.9
+    - python: "3.6"
       env: FLASK=0.8.1
 install:
   - pip install flask==$FLASK coverage

--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -35,7 +35,7 @@ except ImportError:
 from werkzeug import cached_property
 
 # Use Flask's preferred JSON module so that our runtime behavior matches.
-from flask import json_available, templating, template_rendered
+from flask import templating, template_rendered
 
 try:
     from flask import message_flashed
@@ -45,8 +45,13 @@ except ImportError:
     message_flashed = None
     _is_message_flashed = False
 
-if json_available:
+json_available = True
+
+try:
     from flask import json
+except ImportError:
+    json_available = False
+
 
 # we'll use signals for template-related tests if
 # available in this version of Flask


### PR DESCRIPTION
Hi,

Flask 1.1.0 remove json_available for compatibility. Please refer to the Flask commit.

```diff
commit d362399e7ebfe167a27daef20e198ecabed1b49b
Author: Gabriel Saldanha <gabrielcrsaldanha@gmail.com>
Date:   Wed Jun 27 08:23:44 2018 -0300

    :fire: Remove code supposed to be removed at v1.0

diff --git a/flask/__init__.py b/flask/__init__.py
index 1ab13c36..2e5670f5 100644
--- a/flask/__init__.py
+++ b/flask/__init__.py
@@ -43,7 +43,3 @@ from . import json
 # This was the only thing that Flask used to export at one point and it had
 # a more generic name.
 jsonify = json.jsonify
-
-# backwards compat, goes away in 1.0
-from .sessions import SecureCookieSession as Session
-json_available = True
```

thanks,
chang-ning