### PR TITLE
Wekzeug library cached_property changed its namespace since version 1…

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -32,7 +32,10 @@ except ImportError:
     # Python 2 urlparse fallback
     from urlparse import urlparse, urljoin
 
-from werkzeug import cached_property
+try:
+    from werkzeug.utils import cached_property
+except ImportError:
+    from werkzeug import cached_property
 
 # Use Flask's preferred JSON module so that our runtime behavior matches.
 from flask import json_available, templating, template_rendered


### PR DESCRIPTION
Starting from werkzeug version 1, the cached_property class has been relocated from here, in which it was flag already as deprecated:
https://github.com/pallets/werkzeug/blob/0.16.x/src/werkzeug/__init__.py

into here:

https://github.com/pallets/werkzeug/blob/master/src/werkzeug/utils.py

In order to prevent issues in projects still using older versions of the library I am using a conditional import.


