### PR TITLE
docs/index.rst minor fix: Remove 's', 'assertEquals()' line 122 index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,7 +119,7 @@ a special ``json`` attribute appended to the ``Response`` object::
     class TestViews(TestCase):
         def test_some_json(self):
             response = self.client.get("/ajax/")
-            self.assertEquals(response.json, dict(success=True))
+            self.assertEqual(response.json, dict(success=True))
 
 Opt to not render the templates
 -------------------------------


### PR DESCRIPTION
Changed `assertEquals` to `assertEqual` (no `s`).

`assertEquals` gives a `DeprecationWarning: Please use assertEqual instead`. 

No other typos found in index.rst 👍

This is my first contribution to a project, please be nice :) Thank you! <3